### PR TITLE
mbed_bsp/bsp_mbed.h definitions moved to mbed_lib.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mbed-os-example-wifi #
 
+[![Build Status](https://travis-ci.com/iconservo/mbed-os-example-wifi.svg?branch=develop)](https://travis-ci.com/iconservo/mbed-os-example-wifi)
+
 Wi-Fi example for Mbed OS
 
 ## Getting started with the Wi-Fi API ##

--- a/debug_custom.json
+++ b/debug_custom.json
@@ -1,0 +1,60 @@
+{
+    "GCC_ARM": {
+        "common": ["-c", "-Wall", "-Wextra",
+                   "-Wno-unused-parameter", "-Wno-missing-field-initializers",
+                   "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
+                   "-ffunction-sections", "-fdata-sections", "-funsigned-char",
+                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": ["-x", "assembler-with-cpp"],
+        "c": ["-std=gnu99"],
+        "cxx": ["-std=gnu++11", "-fno-rtti", "-Wvla"],
+        "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
+               "-Wl,-n"]
+    },
+    "ARMC6": {
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O0",
+                   "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
+                   "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)="],
+        "asm": [],
+        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
+        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "ld": ["--verbose", "--remove", "--legacyalign", "--no_strict_wchar_size",
+               "--no_strict_enum_size", "--show_full_path"]
+    },
+    "ARM": {
+        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O0", "-g", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": ["--show_full_path"]
+    },
+    "uARM": {
+        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O0", "-D__MICROLIB", "-g",
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": ["--library_type=microlib"]
+    },
+    "IAR": {
+        "common": [
+            "--no_wrap_diagnostics",  "-e",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r", "-DMBED_DEBUG",
+            "-DMBED_TRAP_ERRORS_ENABLED=1", "--enable_restrict"],
+        "asm": [],
+        "c": ["--vla", "--diag_suppress=Pe546"],
+        "cxx": ["--guard_calls", "--no_static_destruction"],
+        "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
+    }
+}

--- a/download.jlink
+++ b/download.jlink
@@ -1,0 +1,4 @@
+r
+loadfile BUILD/NRF52_DK/GCC_ARM/mbed-os-example-wifi.hex
+go
+exit

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+JLinkExe -device NRF52 -if SWD -speed 4000 -jtagconf -1,-1 -autoconnect 1 -CommanderScript download.jlink

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,24 @@
 #include "mbed.h"
 #include "TCPSocket.h"
 
+#include "wifi-winc1500/WINC1500TLSSocket.h"
+
+
+#include "wifi-winc1500/mbed_bsp/bsp_mbed.h"
+
+#include "mbed-http/source/http_request.h"
+
+
+extern "C"
+{
+#include "wifi-winc1500/winc1500/host_drv/driver/include/m2m_wifi.h"
+#include "wifi-winc1500/winc1500/host_drv/driver/source/m2m_hif.h"
+#include "wifi-winc1500/winc1500/host_drv/driver/include/m2m_types.h"
+
+
+}
+
+
 #define internal        1
 #define WIFI_ESP8266    2
 #define WIFI_IDW0XX1    3
@@ -24,6 +42,18 @@
 #define WIFI_WINC1500   5
 
 WiFiInterface *wifi;
+
+static DigitalOut lp_en(LOW_POWER_ENABLE);
+
+
+/** Wi-Fi Settings */
+#define MAIN_WLAN_SSID        "CiklumBiowaveLabs" /* < Destination SSID */
+#define MAIN_WLAN_AUTH        M2M_WIFI_SEC_WPA_PSK /* < Security manner */
+#define MAIN_WLAN_PSK         "Biowave_is_the_best" /* < Password for Destination SSID */
+
+#define MAIN_HTTP_FILE_URL   			"https://home.t.myblossom.com/api/heartbeat/"//"https://httpbin.org/get"//"https://www.google.com"//"httpbin.org/get"//"https://www.myblossom.com/"//"http://home.s.myblossom.com/"
+#define USE_TLS							0//1
+#define PORT							80//443
 
 #if MBED_CONF_APP_WIFI_SHIELD == WIFI_ESP8266
 
@@ -57,12 +87,17 @@ WiFiInterface *WiFiInterface::get_default_instance() {
 #include "WINC1500Interface.h"
 
 WiFiInterface *WiFiInterface::get_default_instance() {
-    static WINC1500Interface winc;
-    return &winc;
+
+	return &WINC1500Interface::getInstance();
 }
 
 #endif
 
+
+FileHandle* mbed::mbed_override_console(int fd) {
+    static UARTSerial s(USBTX, USBRX, 115200);
+    return &s;
+}
 
 const char *sec2str(nsapi_security_t sec)
 {
@@ -86,6 +121,8 @@ const char *sec2str(nsapi_security_t sec)
 int scan_demo(WiFiInterface *wifi)
 {
     WiFiAccessPoint *ap;
+
+    printf("Scan DEMO\n");
 
     printf("Scan:\n");
 
@@ -118,55 +155,85 @@ int scan_demo(WiFiInterface *wifi)
     return count;
 }
 
-void http_demo(NetworkInterface *net)
-{
-    TCPSocket socket;
-    nsapi_error_t response;
+void dump_response(HttpResponse* res) {
+    printf("Status: %d - %s\n", res->get_status_code(), res->get_status_message().c_str());
 
-    printf("Sending HTTP request to www.arm.com...\n");
-
-    // Open a socket on the network interface, and create a TCP connection to www.arm.com
-    response = socket.open(net);
-    if(0 != response) {
-        printf("socket.open() failed: %d\n", response);
-        return;
+    printf("Headers:\n");
+    for (size_t ix = 0; ix < res->get_headers_length(); ix++) {
+        printf("\t%s: %s\n", res->get_headers_fields()[ix]->c_str(), res->get_headers_values()[ix]->c_str());
     }
-
-    response = socket.connect("api.ipify.org", 80);
-    if(0 != response) {
-        printf("Error connecting: %d\n", response);
-        socket.close();
-        return;
-    }
-
-    // Send a simple http request
-    char sbuffer[] = "GET / HTTP/1.1\r\nHost: api.ipify.org\r\nConnection: close\r\n\r\n";
-    nsapi_size_t size = strlen(sbuffer);
-
-    // Loop until whole request send
-    while(size) {
-        response = socket.send(sbuffer+response, size);
-        if (response < 0) {
-            printf("Error sending data: %d\n", response);
-            socket.close();
-            return;
-        }
-        size -= response;
-        printf("sent %d [%.*s]\n", response, strstr(sbuffer, "\r\n")-sbuffer, sbuffer);
-    }
-
-    // Receieve a simple http response and print out the response line
-    char rbuffer[64];
-    response = socket.recv(rbuffer, sizeof rbuffer);
-    if (response < 0) {
-        printf("Error receiving data: %d\n", response);
-    } else {
-        printf("recv %d [%.*s]\n", response, strstr(rbuffer, "\r\n")-rbuffer, rbuffer);
-    }
-
-    // Close the socket to return its memory and bring down the network interface
-    socket.close();
+    printf("\nBody (%d bytes):\n\n%s\n", res->get_body_length(), res->get_body_as_string().c_str());
 }
+
+
+int https_demo(NetworkInterface *net)
+{
+    // Create a TCP socket
+    printf("\n----- Setting up TCP connection -----\n");
+
+    //  TCPSocket* socket = new TCPSocket();
+    WINC1500TLSSocket* socket = new WINC1500TLSSocket();
+
+
+    nsapi_error_t open_result = socket->open((WINC1500Interface *)wifi);
+    if (open_result != 0) {
+        printf("Opening TCPSocket failed... %d\n", open_result);
+        return 1;
+    }
+
+    nsapi_error_t connect_result = socket->connect("home.t.myblossom.com", 443);
+    if (connect_result != 0) {
+        printf("Connecting over TCPSocket failed... %d\n", connect_result);
+        return 1;
+    }
+
+    printf("Connected over TCP to home.t.myblossom.com/api/heartbeat/:443\n");
+
+    mbed_stats_heap_t heap_stats;
+    mbed_stats_heap_get(&heap_stats);
+    printf("Current heap: %lu\r\n", heap_stats.current_size);
+    printf("Max heap size: %lu\r\n", heap_stats.max_size);
+
+    // Do a GET request to https://home.t.myblossom.com/api/heartbeat/
+    {
+        HttpRequest* get_req = new HttpRequest(socket, HTTP_GET, "https://home.t.myblossom.com/api/heartbeat/");
+
+        // By default the body is automatically parsed and stored in a string, this is memory heavy.
+        // To receive chunked response, pass in a callback as third parameter to 'send'.
+        HttpResponse* get_res = get_req->send();
+        if (!get_res) {
+            printf("HttpRequest failed (error code %d)\n", get_req->get_error());
+            return 1;
+        }
+
+        printf("\n----- HTTP GET response -----\n");
+        dump_response(get_res);
+
+        delete get_req;
+    }
+
+    // POST request to httpbin.org
+    {
+        HttpRequest* post_req = new HttpRequest(socket, HTTP_POST, "https://home.t.myblossom.com/api/heartbeat/");
+        post_req->set_header("Content-Type", "application/json");
+
+        const char body[] = "{\"hello\":\"world\"}";
+
+        HttpResponse* post_res = post_req->send(body, strlen(body));
+        if (!post_res) {
+            printf("HttpRequest failed (error code %d)\n", post_req->get_error());
+            return 1;
+        }
+
+        printf("\n----- HTTP POST response -----\n");
+        dump_response(post_res);
+
+        delete post_req;
+    }
+
+    delete socket;
+}
+
 
 int main()
 {
@@ -190,27 +257,28 @@ int main()
         return -1;
     }
 
-    printf("\nConnecting to %s...\n", MBED_CONF_APP_WIFI_SSID);
-    int ret = wifi->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+    printf("\nConnecting to %s...\n", MAIN_WLAN_SSID);
+
+    sint8 ret = wifi->connect(MAIN_WLAN_SSID, MAIN_WLAN_PSK, NSAPI_SECURITY_WPA_WPA2, M2M_WIFI_CH_ALL);
+
     if (ret != 0) {
         printf("\nConnection error: %d\n", ret);
         return -1;
     }
+    else
+    {
+        printf("Success\n\n");
 
-    printf("Success\n\n");
-    printf("MAC: %s\n", wifi->get_mac_address());
-    printf("IP: %s\n", wifi->get_ip_address());
-    printf("Netmask: %s\n", wifi->get_netmask());
-    printf("Gateway: %s\n", wifi->get_gateway());
-    printf("RSSI: %d\n\n", wifi->get_rssi());
+    }
 
-    http_demo(wifi);
+    printf("HTTPS demo with Blossom server\n\n");
+
+    https_demo(wifi);
 
     wifi->disconnect();
 
-#if MBED_CONF_APP_WIFI_SHIELD != internal
-    delete wifi;
-#endif
-
     printf("\nDone\n");
+
+    wait(osWaitForever);
+
 }

--- a/main.cpp
+++ b/main.cpp
@@ -43,7 +43,7 @@ extern "C"
 
 WiFiInterface *wifi;
 
-static DigitalOut lp_en(LOW_POWER_ENABLE);
+//static DigitalOut lp_en(LOW_POWER_ENABLE);
 
 
 /** Wi-Fi Settings */
@@ -194,7 +194,7 @@ int https_demo(NetworkInterface *net)
     printf("Current heap: %lu\r\n", heap_stats.current_size);
     printf("Max heap size: %lu\r\n", heap_stats.max_size);
 
-    // Do a GET request to https://home.t.myblossom.com/api/heartbeat/
+    // Do a GET re_Static_assertquest to https://home.t.myblossom.com/api/heartbeat/
     {
         HttpRequest* get_req = new HttpRequest(socket, HTTP_GET, "https://home.t.myblossom.com/api/heartbeat/");
 

--- a/mbed-http.lib
+++ b/mbed-http.lib
@@ -1,0 +1,1 @@
+https://developer.mbed.org/teams/sandbox/code/mbed-http/#9a04ed79d67e

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -21,9 +21,14 @@
             "value": "D0"
         }
     },
+	 "macros": [
+	    "MBED_HEAP_STATS_ENABLED=1"
+	],
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true
+            "platform.stdio-convert-newlines": true,
+	   "platform.stdio-baud-rate": 115200,
+	   "platform.default-serial-baud-rate": 115200
         },
         "DISCO_F413ZH": {
             "wifi-shield": "WIFI_ISM43362"

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -43,6 +43,17 @@
         "NUCLEO_F401RE": {
             "wifi-tx": "D8",
             "wifi-rx": "D2"
+        },
+        "NRF52_DK": {
+            "winc1500.wifi-miso": "p28",
+            "winc1500.wifi-mosi": "p25",
+            "winc1500.wifi-sclk": "p29",
+            "winc1500.wifi-nss": "p12",
+            "winc1500.wifi-reset": "p14",
+            "winc1500.wifi-wakeup": "p16",
+            "winc1500.wifi-irq": "p15",
+            "winc1500.wifi-chip-enable": "p11",
+            "winc1500.enable_debug": true
         }
     }
 }

--- a/mbed_config.h
+++ b/mbed_config.h
@@ -1,0 +1,152 @@
+/*
+ * mbed SDK
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Automatically generated configuration file.
+// DO NOT EDIT, content will be overwritten.
+
+#ifndef __MBED_CONFIG_DATA__
+#define __MBED_CONFIG_DATA__
+
+// Configuration parameters
+#define MBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT        0                                                                                                // set by library:nanostack-hal
+#define MBED_CONF_CELLULAR_USE_APN_LOOKUP                                     1                                                                                                // set by library:cellular
+#define MBED_CONF_WINC1500_WIFI_DATAREADY                                     NC                                                                                               // set by library:winc1500
+#define MBED_CONF_LORA_DEVICE_EUI                                             {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}                                                 // set by library:lora
+#define MBED_CONF_PLATFORM_ERROR_HIST_ENABLED                                 0                                                                                                // set by library:platform
+#define MBED_CONF_APP_WIFI_RX                                                 D0                                                                                               // set by application
+#define MBED_CONF_EVENTS_PRESENT                                              1                                                                                                // set by library:events
+#define MBED_CONF_PPP_CELL_IFACE_AT_PARSER_TIMEOUT                            8000                                                                                             // set by library:ppp-cell-iface
+#define MBED_LFS_BLOCK_SIZE                                                   512                                                                                              // set by library:littlefs
+#define MBED_CONF_LORA_NWKSKEY                                                {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // set by library:lora
+#define MBED_CONF_LORA_DUTY_CYCLE_ON                                          1                                                                                                // set by library:lora
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_SEC_LEVEL                          5                                                                                                // set by library:mbed-mesh-api
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_PSK_KEY                            {0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf} // set by library:mbed-mesh-api
+#define MBED_CONF_RTOS_PRESENT                                                1                                                                                                // set by library:rtos
+#define MBED_CONF_WINC1500_WIFI_WAKEUP                                        NC                                                                                               // set by library:winc1500
+#define MBED_CONF_PLATFORM_ERROR_ALL_THREADS_INFO                             0                                                                                                // set by library:platform
+#define MBED_CONF_LORA_APP_PORT                                               15                                                                                               // set by library:lora
+#define MBED_CONF_PLATFORM_ERROR_HIST_SIZE                                    4                                                                                                // set by library:platform
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL                         22                                                                                               // set by library:mbed-mesh-api
+#define MBED_CONF_LORA_APPLICATION_EUI                                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}                                                 // set by library:lora
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_CHANNEL_PAGE                       0                                                                                                // set by library:mbed-mesh-api
+#define MBED_LFS_LOOKAHEAD                                                    512                                                                                              // set by library:littlefs
+#define MBED_CONF_APP_WIFI_SHIELD                                             WIFI_ISM43362                                                                                    // set by application[DISCO_L475VG_IOT01A]
+#define MBED_CONF_NSAPI_DNS_RESPONSE_WAIT_TIME                                5000                                                                                             // set by library:nsapi
+#define MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES                             1                                                                                                // set by application[*]
+#define MBED_CONF_NSAPI_DNS_RETRIES                                           0                                                                                                // set by library:nsapi
+#define MBED_LFS_ENABLE_INFO                                                  0                                                                                                // set by library:littlefs
+#define MBED_CONF_EVENTS_SHARED_HIGHPRIO_STACKSIZE                            1024                                                                                             // set by library:events
+#define MBED_CONF_APP_WIFI_SSID                                               "SSID"                                                                                           // set by application
+#define MBED_CONF_WINC1500_WIFI_NSS                                           NC                                                                                               // set by library:winc1500
+#define MBED_CONF_LORA_PUBLIC_NETWORK                                         1                                                                                                // set by library:lora
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL_PAGE                    0                                                                                                // set by library:mbed-mesh-api
+#define MBED_CONF_APP_WIFI_PASSWORD                                           "PASSWORD"                                                                                       // set by application
+#define MBED_CONF_NSAPI_DEFAULT_STACK                                         LWIP                                                                                             // set by library:nsapi
+#define MBED_CONF_APP_WIFI_TX                                                 D1                                                                                               // set by application
+#define MBED_LFS_PROG_SIZE                                                    64                                                                                               // set by library:littlefs
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_DEVICE_TYPE                        NET_6LOWPAN_ROUTER                                                                               // set by library:mbed-mesh-api
+#define MBED_CONF_MBED_MESH_API_THREAD_DEVICE_TYPE                            MESH_DEVICE_TYPE_THREAD_ROUTER                                                                   // set by library:mbed-mesh-api
+#define MBED_CONF_TARGET_LPTICKER_LPTIM                                       1                                                                                                // set by target:DISCO_L475VG_IOT01A
+#define MBED_CONF_PPP_CELL_IFACE_AT_PARSER_BUFFER_SIZE                        256                                                                                              // set by library:ppp-cell-iface
+#define MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR                           0                                                                                                // set by library:platform
+#define MBED_CONF_PLATFORM_STDIO_BAUD_RATE                                    9600                                                                                             // set by library:platform
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_EXTENDED_PANID                  {0xf1, 0xb5, 0xa1, 0xb2,0xc4, 0xd5, 0xa1, 0xbd }                                                 // set by library:mbed-mesh-api
+#define MBED_CONF_LORA_OVER_THE_AIR_ACTIVATION                                1                                                                                                // set by library:lora
+#define MBED_CONF_ISM43362_WIFI_DATAREADY                                     PE_1                                                                                             // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_LORA_LBT_ON                                                 0                                                                                                // set by library:lora
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_CHANNEL_MASK                       0x7fff800                                                                                        // set by library:mbed-mesh-api
+#define MBED_CONF_MBED_MESH_API_USE_MALLOC_FOR_HEAP                           0                                                                                                // set by library:mbed-mesh-api
+#define MBED_CONF_ISM43362_WIFI_MISO                                          PC_11                                                                                            // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_EVENTS_SHARED_EVENTSIZE                                     256                                                                                              // set by library:events
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_PANID_FILTER                       0xffff                                                                                           // set by library:mbed-mesh-api
+#define MBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN                             16                                                                                               // set by library:platform
+#define MBED_CONF_ISM43362_WIFI_SCLK                                          PC_10                                                                                            // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_MBED_MESH_API_HEAP_SIZE                                     32500                                                                                            // set by library:mbed-mesh-api
+#define MBED_CONF_EVENTS_SHARED_STACKSIZE                                     1024                                                                                             // set by library:events
+#define MBED_CONF_ISM43362_WIFI_WAKEUP                                        PB_13                                                                                            // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_THREAD_STACK_SIZE                  6144                                                                                             // set by library:nanostack-hal
+#define MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION          0                                                                                                // set by library:nanostack-hal
+#define MBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES                         0                                                                                                // set by library:platform
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_SECURITY_MODE                      NONE                                                                                             // set by library:mbed-mesh-api
+#define MBED_CONF_LORA_APPLICATION_KEY                                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // set by library:lora
+#define MBED_CONF_ISM43362_WIFI_MOSI                                          PC_12                                                                                            // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_PANID                           0x0700                                                                                           // set by library:mbed-mesh-api
+#define MBED_CONF_LORA_DEVICE_ADDRESS                                         0x00000000                                                                                       // set by library:lora
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_COMMISSIONING_DATASET_TIMESTAMP 0x10000                                                                                          // set by library:mbed-mesh-api
+#define MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT                                1                                                                                                // set by library:platform
+#define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE                              256                                                                                              // set by library:drivers
+#define NVSTORE_MAX_KEYS                                                      16                                                                                               // set by library:nvstore
+#define MBED_CONF_WINC1500_WIFI_MOSI                                          NC                                                                                               // set by library:winc1500
+#define MBED_CONF_WINC1500_WIFI_MISO                                          NC                                                                                               // set by library:winc1500
+#define MBED_CONF_TARGET_LPUART_CLOCK_SOURCE                                  USE_LPUART_CLK_LSE|USE_LPUART_CLK_PCLK1                                                          // set by target:FAMILY_STM32
+#define CLOCK_SOURCE                                                          USE_PLL_MSI                                                                                      // set by target:DISCO_L475VG_IOT01A
+#define MBED_CONF_PLATFORM_STDIO_BUFFERED_SERIAL                              0                                                                                                // set by library:platform
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_ML_PREFIX                       {0xfd, 0x0, 0x0d, 0xb8, 0x0, 0x0, 0x0, 0x0}                                                      // set by library:mbed-mesh-api
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL_MASK                    0x7fff800                                                                                        // set by library:mbed-mesh-api
+#define MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_USE_MBED_EVENTS                    0                                                                                                // set by library:nanostack-hal
+#define MBED_CONF_LORA_TX_MAX_SIZE                                            64                                                                                               // set by library:lora
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_PSK_KEY_ID                         1                                                                                                // set by library:mbed-mesh-api
+#define MBED_CONF_NSAPI_DNS_TOTAL_ATTEMPTS                                    3                                                                                                // set by library:nsapi
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_PSKC                            {0xc8, 0xa6, 0x2e, 0xae, 0xf3, 0x68, 0xf3, 0x46, 0xa9, 0x9e, 0x57, 0x85, 0x98, 0x9d, 0x1c, 0xd0} // set by library:mbed-mesh-api
+#define MBED_CONF_MBED_MESH_API_THREAD_CONFIG_NETWORK_NAME                    "Thread Network"                                                                                 // set by library:mbed-mesh-api
+#define MBED_CONF_LORA_APPSKEY                                                {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // set by library:lora
+#define MBED_CONF_WINC1500_WIFI_RESET                                         NC                                                                                               // set by library:winc1500
+#define MBED_CONF_WINC1500_WIFI_SCLK                                          NC                                                                                               // set by library:winc1500
+#define MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP                                   1                                                                                                // set by library:ppp-cell-iface
+#define MBED_CONF_PLATFORM_ERROR_FILENAME_CAPTURE_ENABLED                     0                                                                                                // set by library:platform
+#define MBED_CONF_LORA_ADR_ON                                                 1                                                                                                // set by library:lora
+#define MBED_CONF_MBED_MESH_API_THREAD_USE_STATIC_LINK_CONFIG                 1                                                                                                // set by library:mbed-mesh-api
+#define MBED_CONF_ISM43362_WIFI_NSS                                           PE_0                                                                                             // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_LORA_AUTOMATIC_UPLINK_MESSAGE                               1                                                                                                // set by library:lora
+#define MBED_CONF_EVENTS_SHARED_DISPATCH_FROM_APPLICATION                     0                                                                                                // set by library:events
+#define MBED_CONF_MBED_MESH_API_THREAD_PSKD                                   "ABCDEFGH"                                                                                       // set by library:mbed-mesh-api
+#define MBED_CONF_NSAPI_DEFAULT_MESH_TYPE                                     THREAD                                                                                           // set by library:nsapi
+#define MBED_CONF_LORA_NB_TRIALS                                              12                                                                                               // set by library:lora
+#define MBED_CONF_LORA_PHY                                                    EU868                                                                                            // set by library:lora
+#define MBED_CONF_MBED_MESH_API_THREAD_SECURITY_POLICY                        255                                                                                              // set by library:mbed-mesh-api
+#define MBED_CONF_NSAPI_PRESENT                                               1                                                                                                // set by library:nsapi
+#define MBED_CONF_FILESYSTEM_PRESENT                                          1                                                                                                // set by library:filesystem
+#define MBED_CONF_PPP_CELL_IFACE_BAUD_RATE                                    115200                                                                                           // set by library:ppp-cell-iface
+#define MBED_CONF_NSAPI_DNS_CACHE_SIZE                                        3                                                                                                // set by library:nsapi
+#define MBED_CONF_PLATFORM_POLL_USE_LOWPOWER_TIMER                            0                                                                                                // set by library:platform
+#define MBED_LFS_READ_SIZE                                                    64                                                                                               // set by library:littlefs
+#define MBED_CONF_ESP8266_DEBUG                                               0                                                                                                // set by library:esp8266
+#define MBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY                                 NONE                                                                                             // set by library:nsapi
+#define MBED_LFS_INTRINSICS                                                   1                                                                                                // set by library:littlefs
+#define MBED_CONF_NANOSTACK_HAL_NVM_CFSTORE                                   0                                                                                                // set by library:nanostack-hal
+#define NVSTORE_ENABLED                                                       1                                                                                                // set by library:nvstore
+#define MBED_CONF_ISM43362_WIFI_RESET                                         PE_8                                                                                             // set by library:ism43362[DISCO_L475VG_IOT01A]
+#define MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE                           9600                                                                                             // set by library:platform
+#define MBED_CONF_CELLULAR_RANDOM_MAX_START_DELAY                             0                                                                                                // set by library:cellular
+#define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE                              256                                                                                              // set by library:drivers
+#define MBED_CONF_MBED_MESH_API_6LOWPAN_ND_CHANNEL                            0                                                                                                // set by library:mbed-mesh-api
+#define MBED_CONF_EVENTS_USE_LOWPOWER_TIMER_TICKER                            0                                                                                                // set by library:events
+#define MBED_CONF_CELLULAR_DEBUG_AT                                           0                                                                                                // set by library:cellular
+#define MBED_CONF_TARGET_LSE_AVAILABLE                                        1                                                                                                // set by target:FAMILY_STM32
+#define MBED_CONF_MBED_MESH_API_THREAD_MASTER_KEY                             {0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff} // set by library:mbed-mesh-api
+#define MBED_CONF_NANOSTACK_CONFIGURATION                                     nanostack_full                                                                                   // set by library:nanostack
+#define MBED_CONF_EVENTS_SHARED_HIGHPRIO_EVENTSIZE                            256                                                                                              // set by library:events
+// Macros
+#define NS_USE_EXTERNAL_MBED_TLS                                                                                                                                               // defined by library:nanostack
+#define CONF_WINC_DEBUG                                                       1                                                                                                // defined by library:winc1500
+#define NM_EDGE_INTERRUPT                                                                                                                                                      // defined by library:winc1500
+#define __APP_APS3_CORTUS__                                                                                                                                                    // defined by library:winc1500
+#define _RTE_                                                                                                                                                                  // defined by library:rtos
+#define UNITY_INCLUDE_CONFIG_H                                                                                                                                                 // defined by library:utest
+#define CONF_WINC_USE_SPI                                                                                                                                                       // defined by library:winc1500
+
+#endif

--- a/wifi-winc1500.lib
+++ b/wifi-winc1500.lib
@@ -1,1 +1,1 @@
-https://github.com/iconservo/wifi-winc1500/#4e65a034f46add804770f4330fa58406f67286d6
+https://github.com/iconservo/wifi-winc1500/#672779263695a48044292d432c5c0104302abe38


### PR DESCRIPTION
winc pins were defined in mbed_lib.json

I've also tried to compile and run the app mbed-wifi-example, it works fine.
you need to update mbed_app.json file in mbed-wifi-example repo to run the code with the following lines in the "target_overrides" section.

    "NRF52_DK": {
        "winc1500.wifi-miso": "p28",
        "winc1500.wifi-mosi": "p25",
        "winc1500.wifi-sclk": "p29",
        "winc1500.wifi-nss": "p12",
        "winc1500.wifi-reset": "p14",
        "winc1500.wifi-wakeup": "p16",
        "winc1500.wifi-irq": "p15",
        "winc1500.wifi-chip-enable": "p11",
        "winc1500.enable_debug": true
    }

I've also committed changes to mbed-os-example-wifi to fit the new structure.
iconservo/mbed-os-example-wifi@d3e2d68 